### PR TITLE
added support for either passenger or passenger-enterprise-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,17 @@ rails) to use passenger by default.
 
 ## Installation
 
-Add this line to your application's `Gemfile`:
+Add the following along with `gem passenger` or `gem 'passenger-enterprise-server'` in your application's `Gemfile`:
 
     gem 'passenger-rails'
 
 And then execute:
 
     $ bundle install
+
+## Upgrading
+
+If you upgrade from v0.0.x, be sure to include `gem 'passenger'` or `gem 'passenger-enterprise-server'`, depending on which you wish to use. Since both are supported, neither can be included as a dependency.
 
 ## Usage
 

--- a/lib/passenger/rails/version.rb
+++ b/lib/passenger/rails/version.rb
@@ -1,5 +1,5 @@
 module Passenger
   module Rails
-    VERSION = '0.0.2'
+    VERSION = '0.1.0'
   end
 end

--- a/passenger-rails.gemspec
+++ b/passenger-rails.gemspec
@@ -16,5 +16,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_dependency 'rack'
-  gem.add_dependency 'passenger'
+
+  # Note: don't explicitly add dependency to passenger, since it could be
+  # either passenger or passenger-enterprise-server.
 end


### PR DESCRIPTION
Some options are available in the passenger-enterprise-server gem that are incompatible with the passenger gem, and since passenger-rails was explicitly requiring the passenger gem, it tried to use the passenger-enterprise-server config with passenger and failed to start. The easiest solution to this is to remove the passenger gem as a dependency in the gemspec which allows passenger start to choose the right passenger that was included in the application Gemfile. The downside is one more line in the Gemfile for those just using the passenger gem, but I think the benefit of not having to fork and maintain a passenger-enterprise-server-rails gem just for that purpose outweighs the requirement for another line. That's up to you though- if you'd fork and have two, that's cool, but I won't have time to keep the other one sync'd. Let me know if this works. Thanks!
